### PR TITLE
Implement basic quiz feature

### DIFF
--- a/apps/client/src/features/editor/components/slash-menu/menu-items.ts
+++ b/apps/client/src/features/editor/components/slash-menu/menu-items.ts
@@ -267,6 +267,27 @@ const CommandGroups: SlashMenuGroupedItemsType = {
         editor.chain().focus().deleteRange(range).toggleCallout().run(),
     },
     {
+      title: "Question",
+      description: "Insert quiz question.",
+      searchTerms: ["quiz", "question", "test"],
+      icon: IconCalendar,
+      command: ({ editor, range }: CommandProps) =>
+        editor
+          .chain()
+          .focus()
+          .deleteRange(range)
+          .setQuestion({ text: "", options: [], answer: 0 })
+          .run(),
+    },
+    {
+      title: "Quiz",
+      description: "Insert quiz block.",
+      searchTerms: ["quiz", "test"],
+      icon: IconAppWindow,
+      command: ({ editor, range }: CommandProps) =>
+        editor.chain().focus().deleteRange(range).setQuiz().run(),
+    },
+    {
       title: "Math inline",
       description: "Insert inline math equation.",
       searchTerms: [

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -37,6 +37,8 @@ import {
   Excalidraw,
   Embed,
   Mention,
+  Question,
+  Quiz,
 } from "@docmost/editor-ext";
 import {
   randomElement,
@@ -210,6 +212,8 @@ export const mainExtensions = [
   Embed.configure({
     view: EmbedView,
   }),
+  Question,
+  Quiz,
   MarkdownClipboard.configure({
     transformPastedText: true,
   }),

--- a/apps/server/src/core/core.module.ts
+++ b/apps/server/src/core/core.module.ts
@@ -16,6 +16,7 @@ import { GroupModule } from './group/group.module';
 import { CaslModule } from './casl/casl.module';
 import { DomainMiddleware } from '../common/middlewares/domain.middleware';
 import { ShareModule } from './share/share.module';
+import { QuizModule } from './quiz/quiz.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ShareModule } from './share/share.module';
     GroupModule,
     CaslModule,
     ShareModule,
+    QuizModule,
   ],
 })
 export class CoreModule implements NestModule {

--- a/apps/server/src/core/quiz/dto/create-question.dto.ts
+++ b/apps/server/src/core/quiz/dto/create-question.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsNumber, IsString } from 'class-validator';
+
+export class CreateQuestionDto {
+  @IsString()
+  text: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  options: string[];
+
+  @IsNumber()
+  answer: number;
+}

--- a/apps/server/src/core/quiz/dto/create-quiz.dto.ts
+++ b/apps/server/src/core/quiz/dto/create-quiz.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateQuizDto {
+  @IsString()
+  title: string;
+}

--- a/apps/server/src/core/quiz/quiz.controller.ts
+++ b/apps/server/src/core/quiz/quiz.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { QuizService } from './quiz.service';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { CreateQuestionDto } from './dto/create-question.dto';
+
+@Controller('quizzes')
+export class QuizController {
+  constructor(private readonly quizService: QuizService) {}
+
+  @Post('create')
+  create(@Body() dto: CreateQuizDto) {
+    return this.quizService.createQuiz(dto);
+  }
+
+  @Post(':id/questions')
+  addQuestion(@Param('id') id: string, @Body() dto: CreateQuestionDto) {
+    return this.quizService.addQuestion(id, dto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.quizService.findQuiz(id);
+  }
+}

--- a/apps/server/src/core/quiz/quiz.module.ts
+++ b/apps/server/src/core/quiz/quiz.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { QuizService } from './quiz.service';
+import { QuizController } from './quiz.controller';
+
+@Module({
+  imports: [],
+  providers: [QuizService],
+  controllers: [QuizController],
+})
+export class QuizModule {}

--- a/apps/server/src/core/quiz/quiz.service.ts
+++ b/apps/server/src/core/quiz/quiz.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { CreateQuestionDto } from './dto/create-question.dto';
+
+interface Question {
+  id: string;
+  text: string;
+  options: string[];
+  answer: number;
+}
+
+interface Quiz {
+  id: string;
+  title: string;
+  questions: Question[];
+}
+
+@Injectable()
+export class QuizService {
+  private quizzes: Quiz[] = [];
+
+  createQuiz(dto: CreateQuizDto): Quiz {
+    const quiz: Quiz = {
+      id: Date.now().toString(),
+      title: dto.title,
+      questions: [],
+    };
+    this.quizzes.push(quiz);
+    return quiz;
+  }
+
+  addQuestion(quizId: string, dto: CreateQuestionDto): Question {
+    const quiz = this.quizzes.find((q) => q.id === quizId);
+    if (!quiz) {
+      throw new NotFoundException('Quiz not found');
+    }
+    const question: Question = {
+      id: Date.now().toString(),
+      text: dto.text,
+      options: dto.options,
+      answer: dto.answer,
+    };
+    quiz.questions.push(question);
+    return question;
+  }
+
+  findQuiz(id: string): Quiz {
+    const quiz = this.quizzes.find((q) => q.id === id);
+    if (!quiz) {
+      throw new NotFoundException('Quiz not found');
+    }
+    return quiz;
+  }
+}

--- a/packages/editor-ext/src/index.ts
+++ b/packages/editor-ext/src/index.ts
@@ -18,3 +18,4 @@ export * from "./lib/embed";
 export * from "./lib/mention";
 export * from "./lib/markdown";
 export * from "./lib/embed-provider";
+export * from "./lib/quiz";

--- a/packages/editor-ext/src/lib/quiz/index.ts
+++ b/packages/editor-ext/src/lib/quiz/index.ts
@@ -1,0 +1,2 @@
+export { Question } from "./question";
+export { Quiz } from "./quiz";

--- a/packages/editor-ext/src/lib/quiz/question.ts
+++ b/packages/editor-ext/src/lib/quiz/question.ts
@@ -1,0 +1,92 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+
+export interface QuestionOptions {
+  HTMLAttributes: Record<string, any>;
+}
+
+export interface QuestionAttributes {
+  text: string;
+  options: string[];
+  answer: number;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    question: {
+      setQuestion: (attributes: QuestionAttributes) => ReturnType;
+    };
+  }
+}
+
+export const Question = Node.create<QuestionOptions>({
+  name: "question",
+  group: "block",
+  atom: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      text: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-question-text"),
+        renderHTML: (attributes) => ({
+          "data-question-text": attributes.text,
+        }),
+      },
+      options: {
+        default: [],
+        parseHTML: (element) => {
+          const data = element.getAttribute("data-question-options");
+          try {
+            return data ? JSON.parse(data) : [];
+          } catch {
+            return [];
+          }
+        },
+        renderHTML: (attributes) => ({
+          "data-question-options": JSON.stringify(attributes.options || []),
+        }),
+      },
+      answer: {
+        default: 0,
+        parseHTML: (element) => {
+          const val = element.getAttribute("data-question-answer");
+          return val ? Number(val) : 0;
+        },
+        renderHTML: (attributes) => ({
+          "data-question-answer": attributes.answer,
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: `div[data-type="${this.name}"]`,
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes({ "data-type": this.name }, this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setQuestion:
+        (attrs: QuestionAttributes) =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name, attrs }),
+    };
+  },
+});

--- a/packages/editor-ext/src/lib/quiz/quiz.ts
+++ b/packages/editor-ext/src/lib/quiz/quiz.ts
@@ -1,0 +1,50 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+
+export interface QuizOptions {
+  HTMLAttributes: Record<string, any>;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    quiz: {
+      setQuiz: () => ReturnType;
+    };
+  }
+}
+
+export const Quiz = Node.create<QuizOptions>({
+  name: "quiz",
+  group: "block",
+  content: "question+",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: `div[data-type="${this.name}"]`,
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes({ "data-type": this.name }, this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setQuiz:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name }),
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- add question and quiz extensions for the editor
- expose them through editor extensions and slash menu
- scaffold quiz API on the server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e1537bbb08327a9c0d2c2be90694b